### PR TITLE
THY-fix-psalm-patch

### DIFF
--- a/src/constants/booklist.ts
+++ b/src/constants/booklist.ts
@@ -17,7 +17,7 @@ export const BOOKS: string[] = [
   'NEHEMIAH',
   'ESTHER',
   'JOB',
-  'PSALMS',
+  'PSALM',
   'PROVERBS',
   'ECCLESIASTES',
   'SONGOFSOLOMON',


### PR DESCRIPTION
While the book of the Bible is titled "Psalms", when a verse is quoted from it, the reference uses the word "Psalm".
This patch fix updates the name in the constants file so that validation will be correct.